### PR TITLE
fix(stream): #WCONF-47 hide "start stream" button when stream is not activated

### DIFF
--- a/src/main/resources/public/template/current-room.html
+++ b/src/main/resources/public/template/current-room.html
@@ -105,7 +105,7 @@
                                 <i18n ng-show="!vm.hasActiveSession(vm.selectedRoom)">webconference.room.start</i18n>
                                 <i18n ng-show="vm.hasActiveSession(vm.selectedRoom)">webconference.room.join</i18n>
                             </button>
-                            <button style="margin-left: 5px" ng-if="vm.hasActiveSession(vm.selectedRoom)" ng-click="vm.updateStream(vm.selectedRoom)">
+                            <button style="margin-left: 5px" ng-if="vm.hasActiveSession(vm.selectedRoom) && vm.selectedRoom.allow_streaming" ng-click="vm.updateStream(vm.selectedRoom)">
                                 <i18n ng-show="vm.selectedRoom.isStreaming">webconference.room.streaming.stop</i18n>
                                 <i18n ng-show="!vm.selectedRoom.isStreaming">webconference.room.streaming.start</i18n>
                             </button>


### PR DESCRIPTION
## Describe your changes
Lorsque la salle n'a pas était crée avec un lien de streaming, il ne faut pas afficher la possibilité de lancer un stream.

## Checklist tests
Crée une salle sans salle de streaming.
Le bouton lancer le stream n'est plus disponible.

## Issue ticket number and link
https://entsupport.gdapublic.fr/projects/WCONF/issues/WCONF-47

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequences regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequence feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
