### PR TITLE
fix(rights): #WCONF-53 fix access when user have only view right

### DIFF
--- a/src/main/resources/public/template/current-room.html
+++ b/src/main/resources/public/template/current-room.html
@@ -5,7 +5,7 @@
                 <h2 class="six twelve-mobile">
                     [[vm.selectedRoom.name]]
                 </h2>
-                <div class="six button zero-mobile">
+                <div class="six button zero-mobile" ng-if="vm.hasWorkflowCreate(vm.selectedRoom)">
                     <button ng-click="vm.startCurrentRoom()">
                         <i18n ng-show="!vm.hasActiveSession(vm.selectedRoom)">webconference.room.start</i18n>
                         <i18n ng-show="vm.hasActiveSession(vm.selectedRoom)">webconference.room.join</i18n>

--- a/src/main/resources/public/template/toaster.html
+++ b/src/main/resources/public/template/toaster.html
@@ -1,4 +1,4 @@
-<section class="toggle-buttons" ng-if="vm.rooms && vm.rooms.all.length > 0 && vm.hasShareRightManager(vm.selectedRoom)">
+<section class="toggle-buttons" ng-if="vm.rooms && vm.rooms.all.length > 0 && vm.hasShareRightManager(vm.selectedRoom) && vm.hasWorkflowCreate(vm.selectedRoom)">
     <div class="toggle">
         <div class="row">
             <button ng-click="vm.openRoomUpdate(vm.selectedRoom)" ng-if="!vm.hasActiveSession(vm.selectedRoom)" class="cell">


### PR DESCRIPTION
## Describe your changes

When a user have only **webconference.view** right and someone shares a room with him, he does not have access to the different elements.
This isn't supposed to happen, so now if the user doesn't have the **webconference.create** right, they can't edit, or open a room.

## Checklist tests

* Log in with an account with **webconference.create** rights.
* Create a room, he is supposed to be able to modify, open or close his room.
* Shares the room with a user with only **webconference.view** rights
* The user does not have access to room modifications, and cannot manage it, he only has the room link

## Issue ticket number and link

[https://jira.support-ent.fr/browse/WCONF-53](https://jira.support-ent.fr/browse/WCONF-53)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [X] I have detailed the tests to do in my feature/fix in order to prevent consequences regressions (must specify in **Checklist tests**)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequence feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
