### PR TITLE
fix(links): #WCONF-66 safari cant open links

### DIFF
--- a/src/main/resources/public/ts/controllers/main.ts
+++ b/src/main/resources/public/ts/controllers/main.ts
@@ -70,7 +70,6 @@ interface ViewModel {
 	updateStream(room: Room): Promise<void>;
 	isRunning(room: Room): Promise<boolean>;
 	refresh();
-
 }
 
 function processStructures(): Array<IStructure> {
@@ -337,19 +336,21 @@ export const mainController = ng.controller('MainController',
 			}
 			else {
 				vm.selectedRoom.sessions++;
-				let result = window.open(vm.selectedRoom.link);
-				result.window.onload = function () {
-					if (result.error) {
-						vm.selectedRoom.active_session = null;
-						switch (result.error) {
-							case "tooManyRoomsPerStructure": break;
-							case "tooManyUsers": break;
-							case "tooManyRooms": break;
-							default: notify.error(idiom.translate('webconference.room.end.error')); break;
+				setTimeout(() => {
+					let result = window.open(vm.selectedRoom.link);
+					result.window.onload = function () {
+						if (result.error) {
+							vm.selectedRoom.active_session = null;
+							switch (result.error) {
+								case "tooManyRoomsPerStructure": break;
+								case "tooManyUsers": break;
+								case "tooManyRooms": break;
+								default: notify.error(idiom.translate('webconference.room.end.error')); break;
+							}
 						}
-					}
-					$scope.safeApply();
-				};
+						$scope.safeApply();
+					};
+				})
 				vm.selectedRoom.active_session = '';
 				vm.selectedRoom.opener = model.me.username;
 				$scope.safeApply();


### PR DESCRIPTION
## Describe your changes

Safari is blocking any call to `window.open()` which is made inside an async call.
The solution is to put all our redirection in a `setTimeout`, so that the `window.open()` is no longer in an asynchronous function.

## Checklist tests

* Open a room with Windows
* Open a room with MacOS
* Open a room with IOS

## Issue ticket number and link

[https://jira.support-ent.fr/browse/WCONF-66](https://jira.support-ent.fr/browse/WCONF-66)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [X] I have detailed the tests to do in my feature/fix in order to prevent consequences regressions (must specify in **Checklist tests**)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequence feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)
